### PR TITLE
Allow emojis in the GitHub worker

### DIFF
--- a/github-filter-worker/src/bindings.d.ts
+++ b/github-filter-worker/src/bindings.d.ts
@@ -1,5 +1,5 @@
 declare global {
-    const EMOJIS: KVNamespace
+    const SHIPIT_EMOTE: string
     const HONEYCOMB_KEY: string
 }
 

--- a/github-filter-worker/src/bindings.d.ts
+++ b/github-filter-worker/src/bindings.d.ts
@@ -1,5 +1,5 @@
 declare global {
-    const emojis: KVNamespace
+    const EMOJIS: KVNamespace
     const HONEYCOMB_KEY: string
 }
 

--- a/github-filter-worker/src/bindings.d.ts
+++ b/github-filter-worker/src/bindings.d.ts
@@ -1,4 +1,5 @@
 declare global {
+    const emojis: KVNamespace
     const HONEYCOMB_KEY: string
 }
 

--- a/github-filter-worker/src/index.ts
+++ b/github-filter-worker/src/index.ts
@@ -11,7 +11,7 @@ const hcConfig: Config = {
     'exception': 1
   }
 }
-const emojiRegex = /:([a-zA-Z0-9-_])+?:/g
+const emojiRegex = /(?<!\\):([a-zA-Z0-9-_])+?:/g
 
 const listener = hc(hcConfig, event => {
   event.respondWith(handleRequest(event.request))

--- a/github-filter-worker/src/index.ts
+++ b/github-filter-worker/src/index.ts
@@ -11,7 +11,7 @@ const hcConfig: Config = {
     'exception': 1
   }
 }
-const emojiRegex = new RegExp(":([a-zA-Z0-9-_])+?:")
+const emojiRegex = /:([a-zA-Z0-9-_])+?:/g
 
 const listener = hc(hcConfig, event => {
   event.respondWith(handleRequest(event.request))
@@ -22,7 +22,7 @@ addEventListener('fetch', listener)
 // Try to lookup the emoji through the KV namespace, return the name if not found
 async function lookupEmoji(name: string): string {
   let value = await EMOJIS.get(name)
-  return value === null ? value : name
+  return value ? value : name
 }
 
 export async function handleRequest(request: Request): Promise<Response> {
@@ -84,7 +84,7 @@ export async function handleRequest(request: Request): Promise<Response> {
     let new_request = new Request(template, {
       body: (await request.text()).replace(
           emojiRegex,
-          function(p1) {return lookupEmoji(p1)}
+          (match) => {return lookupEmoji(match)}
       ),
       headers: request.headers,
       method: request.method

--- a/github-filter-worker/src/index.ts
+++ b/github-filter-worker/src/index.ts
@@ -80,17 +80,19 @@ export async function handleRequest(request: Request): Promise<Response> {
     // Format for a webhook
     let template = `https://discord.com/api/webhooks/${id}/${token}/github`;
 
+    let requestText = await request.text();
+
     // Translate emojis to the in-server emoji
     let promises: any[] = [];
-    (await request.text()).match(emojiRegex)?.forEach (
+    requestText.match(emojiRegex)?.forEach (
         (match) => {promises.push(lookupEmoji(match))}
         )
     let emojis: string[] = await Promise.all(promises)
 
     let new_request = new Request(template, {
-      body: (await request.text()).replace(
+      body: requestText.replace(
           emojiRegex,
-          () => {return emojis.shift()}
+          () => {return emojis.shift()!}
       ),
       headers: request.headers,
       method: request.method

--- a/github-filter-worker/src/index.ts
+++ b/github-filter-worker/src/index.ts
@@ -21,7 +21,7 @@ addEventListener('fetch', listener)
 
 // Try to lookup the emoji through the KV namespace, return the name if not found
 async function lookupEmoji(name: string): string {
-  let value = await emojis.get(name)
+  let value = await EMOJIS.get(name)
   return value === null ? value : name
 }
 

--- a/github-filter-worker/wrangler.toml
+++ b/github-filter-worker/wrangler.toml
@@ -5,3 +5,6 @@ workers_dev = true
 route = ""
 zone_id = ""
 webpack_config = "webpack.config.js"
+kv_namespaces = [
+  { binding = "EMOJIS", id = "183f1ae82b8d458f983e39eb2c99fa9a", preview_id = "183f1ae82b8d458f983e39eb2c99fa9a" }
+]

--- a/github-filter-worker/wrangler.toml
+++ b/github-filter-worker/wrangler.toml
@@ -5,6 +5,4 @@ workers_dev = true
 route = ""
 zone_id = ""
 webpack_config = "webpack.config.js"
-kv_namespaces = [
-  { binding = "EMOJIS", id = "183f1ae82b8d458f983e39eb2c99fa9a", preview_id = "183f1ae82b8d458f983e39eb2c99fa9a" }
-]
+vars = { SHIPIT_EMOTE = "<:shipit:826492371813400637>" }


### PR DESCRIPTION
This should make the GitHub filter worker lookup a new `emojis` namespace for how to translate literal emojis such as `:shipit:` to their in-server version.

Not tested yet, I can't really make the worker work.