### PR TITLE
Support Webhooks From Labels

### DIFF
--- a/github-filter-worker/README.md
+++ b/github-filter-worker/README.md
@@ -19,3 +19,5 @@ After you've authorised, you can make modifications to the worker and run `wrang
 Once the worker is active on a domain simply add a GitHub webhook pointing to `https://example.com/{webhook_id}/{webhook_token}`.
 
 All events will be proxied to that hook (providing they don't come from a bot).
+
+To forward data to extra webhooks based on labels, create an entry in the KV namespace `labels` in the format: `<LABEL_NAME>: <:id/:token>`.

--- a/github-filter-worker/src/bindings.d.ts
+++ b/github-filter-worker/src/bindings.d.ts
@@ -1,4 +1,5 @@
 declare global {
+  const labels: KVNamespace
   const HONEYCOMB_KEY: string
 }
 

--- a/github-filter-worker/src/index.ts
+++ b/github-filter-worker/src/index.ts
@@ -93,7 +93,7 @@ export async function handleRequest(request: Request): Promise<Response> {
     const resp = await sendWebhook(id, token, data)
 
     // Send data to any extra label webhooks
-    let extraChannels = json.issue?.labels?.map(
+    let extraChannels = (json.issue || json.pull_request)?.labels?.map(
       async (label: { [key: string]: string }) => {
         let result = await sendLabelWebhook(label.name, data)
 

--- a/github-filter-worker/wrangler.toml
+++ b/github-filter-worker/wrangler.toml
@@ -6,3 +6,6 @@ route = ""
 zone_id = ""
 webpack_config = "webpack.config.js"
 vars = { SHIPIT_EMOTE = "<:shipit:826492371813400637>" }
+kv_namespaces = [
+    { binding = "labels", id = "" }
+]

--- a/github-filter-worker/wrangler.toml
+++ b/github-filter-worker/wrangler.toml
@@ -7,5 +7,5 @@ zone_id = ""
 webpack_config = "webpack.config.js"
 vars = { SHIPIT_EMOTE = "<:shipit:826492371813400637>" }
 kv_namespaces = [
-    { binding = "labels", id = "" }
+    { binding = "labels", id = "37d66bb1cfc3401ab0528ad15ab2bbe6" }
 ]


### PR DESCRIPTION
Adds support for sending data to a webhook based on an issue label.

To configure, create entries in the `labels` KV namespace in the format:
`<LABEL NAME>: <:id/:token>`

Both PRs and issues are supported. Logs are added whenever we send to an extra channel.