### PR TITLE
Fix `Deployment` heading in github-filter readme

### DIFF
--- a/github-filter/README.md
+++ b/github-filter/README.md
@@ -6,7 +6,7 @@ This is particularly useful when relaying embeds to Discord when the embed sizes
 
 This tool is built at the moment only to handle Discord webhooks.
 
-## Deployment
+## Deployment
 
 You need to install `wrangler` with `npm install -g @cloudflare/wrangler`.
 


### PR DESCRIPTION
Somehow a [non breaking space](https://discord.com/channels/267624335836053506/635950537262759947/907597707051405322) creeped up in here that makes github not render it as a proper heading. Toggle rich diff, else it looks like nothing has changed 😄 