### PR TITLE
fix: use a stricter token regex

### DIFF
--- a/hastebin-filter/index.js
+++ b/hastebin-filter/index.js
@@ -2,7 +2,7 @@ addEventListener('fetch', event => {
   event.respondWith(handleRequest(event.request))
 })
 
-const TOKEN_RE = new RegExp("([\\w\\-=]+)\\.([\\w\\-=]+)\\.([\\w\\-=]+)")
+const TOKEN_RE = new RegExp(/(mfa\.[a-z0-9_-]{20,})|([a-z0-9_-]{23,28}\.[a-z0-9_-]{6,7}\.[a-z0-9_-]{27})/, "i")
 const ERROR_MESSAGE = "We detected that you tried to upload a seemingly valid token. For security reasons, we blocked the upload. Please remove it and try again."
 
 async function handleRequest(request) {


### PR DESCRIPTION
this regex was taken from a message in ddevs, listing the regex used by the client to detect tokens

Closes issue mentioned in https://canary.discord.com/channels/267624335836053506/635950537262759947/919055933651419166