### PR TITLE
fix: filter new discord tokens

### DIFF
--- a/hastebin-filter/index.js
+++ b/hastebin-filter/index.js
@@ -2,7 +2,7 @@ addEventListener('fetch', event => {
   event.respondWith(handleRequest(event.request))
 })
 
-const TOKEN_RE = new RegExp(/(mfa\.[a-z0-9_-]{20,})|([a-z0-9_-]{23,28}\.[a-z0-9_-]{6,7}\.[a-z0-9_-]{27})/, "i")
+const TOKEN_RE = new RegExp(/(mfa\.[a-z0-9_-]{20,})|([a-z0-9_-]{23,28}\.[a-z0-9_-]{6,7}\.[a-z0-9_-]{27,})/, "i")
 const ERROR_MESSAGE = "We detected that you tried to upload a seemingly valid token. For security reasons, we blocked the upload. Please remove it and try again."
 
 async function handleRequest(request) {


### PR DESCRIPTION
tokens HMAC can now be longer than 27 characters, but existing ones are still valid