### PR TITLE
Return errors from Discord to the worker caller

### DIFF
--- a/github-filter/src/index.ts
+++ b/github-filter/src/index.ts
@@ -138,7 +138,13 @@ async function sendWebhook(id: string, token: string, data: Data) {
   });
 
   // Pass on data to Discord as usual
-  return await fetch(template, new_request);
+  const response = await fetch(template, new_request);
+  if (!response.ok) {
+    return new Response(response.json(), {
+      status: response.status,
+    });
+  }
+  return response;
 }
 
 export default wrapModule(hcConfig, worker);


### PR DESCRIPTION
Previously, this would result in a 500 error from Cloudflare if the request to Discord would fail for any reason, making it hard to determine the cause of the issue.