### PR TITLE
Forward github's IP to Discord upon sending webhooks

### DIFF
--- a/github-filter/src/index.ts
+++ b/github-filter/src/index.ts
@@ -66,10 +66,18 @@ const worker = {
       if (url.pathname === "/") {
         return new Response("Make sure to specify webhook components like /:id/:token", { status: 400 });
       }
+      
+      const githubIp  = request.headers.get('CF-Connecting-IP');
+      
+      let headers = {...request.headers};
+
+      if (githubIp) {
+        headers = {...headers, 'X-Forwarded-For': githubIp};
+      }
 
       const data: Data = {
         body: await request.text(),
-        headers: request.headers,
+        headers: headers,
         method: request.method,
       };
 

--- a/github-filter/src/index.ts
+++ b/github-filter/src/index.ts
@@ -66,13 +66,13 @@ const worker = {
       if (url.pathname === "/") {
         return new Response("Make sure to specify webhook components like /:id/:token", { status: 400 });
       }
-      
-      const githubIp  = request.headers.get('CF-Connecting-IP');
-      
-      let headers = {...request.headers};
+
+      const githubIp = request.headers.get("CF-Connecting-IP");
+
+      let headers = { ...request.headers };
 
       if (githubIp) {
-        headers = {...headers, 'X-Forwarded-For': githubIp};
+        headers = { ...headers, "X-Forwarded-For": githubIp };
       }
 
       const data: Data = {


### PR DESCRIPTION
We're currently being ratelimited by Discord upon sending the webhook from our worker.

We're not sure if forwarding Github's IP to Discord will solve the issue, but this is an attempt to let discord know the orignal sender's IP address.